### PR TITLE
Implement np style arange for Tensor (#2849)

### DIFF
--- a/cpp/open3d/core/CMakeLists.txt
+++ b/cpp/open3d/core/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(KERNEL_SRC
+    kernel/Arange.cpp
+    kernel/ArangeCPU.cpp
     kernel/IndexGetSet.cpp
     kernel/IndexGetSetCPU.cpp
     kernel/NonZero.cpp
@@ -15,12 +17,13 @@ set(KERNEL_SRC
 )
 
 set(KERNEL_CUDA_SRC
+    kernel/ArangeCUDA.cu
     kernel/IndexGetSetCUDA.cu
     kernel/NonZeroCUDA.cu
     kernel/UnaryEWCUDA.cu
     kernel/BinaryEWCUDA.cu
     kernel/GeneralEWCUDA.cu
-    kernel/ReductionCUDA.cu    
+    kernel/ReductionCUDA.cu
 )
 
 set(LINALG_SRC

--- a/cpp/open3d/core/Tensor.cpp
+++ b/cpp/open3d/core/Tensor.cpp
@@ -36,6 +36,7 @@
 #include "open3d/core/ShapeUtil.h"
 #include "open3d/core/SizeVector.h"
 #include "open3d/core/TensorKey.h"
+#include "open3d/core/kernel/Arange.h"
 #include "open3d/core/kernel/Kernel.h"
 #include "open3d/core/linalg/Inverse.h"
 #include "open3d/core/linalg/LeastSquares.h"
@@ -207,6 +208,12 @@ Tensor Tensor::Diag(const Tensor& input) {
     Tensor diag = Tensor::Zeros({n, n}, input.GetDtype(), input.GetDevice());
     diag.AsStrided({n}, {diag.strides_[0] + diag.strides_[1]}) = input;
     return diag;
+}
+
+Tensor Tensor::Arange(const Tensor& start,
+                      const Tensor& stop,
+                      const Tensor& step) {
+    return kernel::Arange(start, stop, step);
 }
 
 Tensor Tensor::GetItem(const TensorKey& tk) const {
@@ -1268,29 +1275,54 @@ bool Tensor::IsSame(const Tensor& other) const {
            dtype_ == other.dtype_;
 }
 
-void Tensor::AssertShape(const SizeVector& expected_shape) const {
+void Tensor::AssertShape(const SizeVector& expected_shape,
+                         const std::string& error_msg) const {
     if (shape_ != expected_shape) {
-        utility::LogError("Tensor shape {} does not match expected shape: {}",
-                          shape_, expected_shape);
+        if (error_msg.empty()) {
+            utility::LogError(
+                    "Tensor has shape {}, but it is expected to be {}.", shape_,
+                    expected_shape);
+        } else {
+            utility::LogError(
+                    "Tensor has shape {}, but it is expected to be {}: {}",
+                    shape_, expected_shape, error_msg);
+        }
     }
 }
 
-void Tensor::AssertShapeCompatible(
-        const DynamicSizeVector& expected_shape) const {
-    GetShape().AssertCompatible(expected_shape);
+void Tensor::AssertShapeCompatible(const DynamicSizeVector& expected_shape,
+                                   const std::string& error_msg) const {
+    GetShape().AssertCompatible(expected_shape, error_msg);
 }
 
-void Tensor::AssertDevice(const Device& expected_device) const {
+void Tensor::AssertDevice(const Device& expected_device,
+                          const std::string& error_msg) const {
     if (GetDevice() != expected_device) {
-        utility::LogError("Tensor has device {}, but is expected to be {}.",
-                          GetDevice().ToString(), expected_device.ToString());
+        if (error_msg.empty()) {
+            utility::LogError("Tensor has device {}, but is expected to be {}",
+                              GetDevice().ToString(),
+                              expected_device.ToString());
+        } else {
+            utility::LogError(
+                    "Tensor has device {}, but is expected to be {}: {}",
+                    GetDevice().ToString(), expected_device.ToString(),
+                    error_msg);
+        }
     }
 }
 
-void Tensor::AssertDtype(const Dtype& expected_dtype) const {
+void Tensor::AssertDtype(const Dtype& expected_dtype,
+                         const std::string& error_msg) const {
     if (GetDtype() != expected_dtype) {
-        utility::LogError("Tensor has dtype {}, but is expected to be {}.",
-                          GetDtype().ToString(), expected_dtype.ToString());
+        if (error_msg.empty()) {
+            utility::LogError("Tensor has dtype {}, but is expected to be {}.",
+                              GetDtype().ToString(), expected_dtype.ToString());
+        } else {
+            utility::LogError(
+                    "Tensor has dtype {}, but is expected to be {}: {}",
+                    GetDtype().ToString(), expected_dtype.ToString(),
+                    error_msg);
+        }
     }
 }
 

--- a/cpp/open3d/core/Tensor.h
+++ b/cpp/open3d/core/Tensor.h
@@ -332,6 +332,30 @@ public:
     /// Create a square matrix with specified diagonal elements in input.
     static Tensor Diag(const Tensor& input);
 
+    /// Create a 1D tensor with evenly spaced values in the given interval.
+    static Tensor Arange(const Tensor& start,
+                         const Tensor& stop,
+                         const Tensor& step);
+
+    template <typename T>
+    static Tensor Arange(T start,
+                         T stop,
+                         T step = 1,
+                         const Device& device = core::Device("CPU:0")) {
+        Dtype dtype = Dtype::FromType<T>();
+        if (step == 0) {
+            utility::LogError("Step cannot be 0");
+        }
+        if (stop == start) {
+            return Tensor({0}, dtype, device);
+        }
+
+        Tensor tstart = Tensor::Full({}, start, dtype, device);
+        Tensor tstop = Tensor::Full({}, stop, dtype, device);
+        Tensor tstep = Tensor::Full({}, step, dtype, device);
+        return Arange(tstart, tstop, tstep);
+    }
+
     /// Pythonic __getitem__ for tensor.
     ///
     /// Returns a view of the original tensor, if TensorKey is
@@ -1129,16 +1153,20 @@ public:
     static Tensor FromDLPack(const DLManagedTensor* dlmt);
 
     /// Assert that the Tensor has the specified shape.
-    void AssertShape(const SizeVector& expected_shape) const;
+    void AssertShape(const SizeVector& expected_shape,
+                     const std::string& error_msg = "") const;
 
     /// Assert that Tensor's shape is compatible with a dynamic shape.
-    void AssertShapeCompatible(const DynamicSizeVector& expected_shape) const;
+    void AssertShapeCompatible(const DynamicSizeVector& expected_shape,
+                               const std::string& error_msg = "") const;
 
     /// Assert that the Tensor has the specified device.
-    void AssertDevice(const Device& expected_device) const;
+    void AssertDevice(const Device& expected_device,
+                      const std::string& error_msg = "") const;
 
     /// Assert that the Tensor has the specified dtype.
-    void AssertDtype(const Dtype& expected_dtype) const;
+    void AssertDtype(const Dtype& expected_dtype,
+                     const std::string& error_msg = "") const;
 
 protected:
     std::string ScalarPtrToString(const void* ptr) const;

--- a/cpp/open3d/core/kernel/Arange.cpp
+++ b/cpp/open3d/core/kernel/Arange.cpp
@@ -1,0 +1,103 @@
+// ----------------------------------------------------------------------------
+// -                        Open3D: www.open3d.org                            -
+// ----------------------------------------------------------------------------
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 www.open3d.org
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+// ----------------------------------------------------------------------------
+
+#include "open3d/core/kernel/Arange.h"
+
+#include "open3d/core/Tensor.h"
+#include "open3d/core/kernel/GeneralEW.h"
+
+namespace open3d {
+namespace core {
+namespace kernel {
+
+Tensor Arange(const Tensor& start, const Tensor& stop, const Tensor& step) {
+    start.AssertShape({}, "Start tensor must have shape {}.");
+    stop.AssertShape({}, "Stop tensor must have shape {}.");
+    step.AssertShape({}, "Step tensor must have shape {}.");
+
+    Device device = start.GetDevice();
+    Device::DeviceType device_type = device.GetType();
+    stop.AssertDevice(device,
+                      "Stop must have the same dtype and device as start.");
+    step.AssertDevice(device,
+                      "Step must have the same dtype and device as start.");
+
+    int64_t num_elements = 0;
+    bool is_arange_valid = true;
+
+    Dtype dtype = start.GetDtype();
+    DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
+        scalar_t sstart = start.Item<scalar_t>();
+        scalar_t sstop = stop.Item<scalar_t>();
+        scalar_t sstep = step.Item<scalar_t>();
+
+        if (sstep == 0) {
+            utility::LogError("Step cannot be 0");
+        }
+        if (sstart == sstop) {
+            is_arange_valid = false;
+        }
+
+        num_elements = static_cast<int64_t>(
+                std::ceil(static_cast<double>(sstop - sstart) /
+                          static_cast<double>(sstep)));
+        if (num_elements <= 0) {
+            is_arange_valid = false;
+        }
+    });
+
+    // Special case.
+    if (!is_arange_valid) {
+        return Tensor({0}, dtype, device);
+    }
+
+    // Input parameters.
+    std::unordered_map<std::string, core::Tensor> srcs = {
+            {"start", start},
+            {"step", step},
+    };
+
+    // Output.
+    Tensor dst = Tensor({num_elements}, dtype, device);
+
+    if (device_type == Device::DeviceType::CPU) {
+        ArangeCPU(start, stop, step, dst);
+    } else if (device_type == Device::DeviceType::CUDA) {
+#ifdef BUILD_CUDA_MODULE
+        ArangeCUDA(start, stop, step, dst);
+#else
+        utility::LogError("Not compiled with CUDA, but CUDA device is used.");
+#endif
+    } else {
+        utility::LogError("Arange: Unimplemented device.");
+    }
+
+    return dst;
+}
+
+}  // namespace kernel
+}  // namespace core
+}  // namespace open3d

--- a/cpp/open3d/core/kernel/Arange.h
+++ b/cpp/open3d/core/kernel/Arange.h
@@ -32,12 +32,18 @@ namespace open3d {
 namespace core {
 namespace kernel {
 
-Tensor NonZero(const Tensor& src);
+Tensor Arange(const Tensor& start, const Tensor& stop, const Tensor& step);
 
-Tensor NonZeroCPU(const Tensor& src);
+void ArangeCPU(const Tensor& start,
+               const Tensor& stop,
+               const Tensor& step,
+               Tensor& dst);
 
 #ifdef BUILD_CUDA_MODULE
-Tensor NonZeroCUDA(const Tensor& src);
+void ArangeCUDA(const Tensor& start,
+                const Tensor& stop,
+                const Tensor& step,
+                Tensor& dst);
 #endif
 
 }  // namespace kernel

--- a/cpp/open3d/core/kernel/ArangeCPU.cpp
+++ b/cpp/open3d/core/kernel/ArangeCPU.cpp
@@ -24,21 +24,31 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#pragma once
-
+#include "open3d/core/Dispatch.h"
 #include "open3d/core/Tensor.h"
+#include "open3d/core/kernel/Arange.h"
+#include "open3d/core/kernel/CPULauncher.h"
 
 namespace open3d {
 namespace core {
 namespace kernel {
 
-Tensor NonZero(const Tensor& src);
-
-Tensor NonZeroCPU(const Tensor& src);
-
-#ifdef BUILD_CUDA_MODULE
-Tensor NonZeroCUDA(const Tensor& src);
-#endif
+void ArangeCPU(const Tensor& start,
+               const Tensor& stop,
+               const Tensor& step,
+               Tensor& dst) {
+    Dtype dtype = start.GetDtype();
+    DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
+        scalar_t sstart = start.Item<scalar_t>();
+        scalar_t sstep = step.Item<scalar_t>();
+        scalar_t* dst_ptr = static_cast<scalar_t*>(dst.GetDataPtr());
+        int64_t n = dst.GetLength();
+        CPULauncher::LaunchGeneralKernel(n, [&](int64_t workload_idx) {
+            dst_ptr[workload_idx] =
+                    sstart + static_cast<scalar_t>(sstep * workload_idx);
+        });
+    });
+}
 
 }  // namespace kernel
 }  // namespace core

--- a/cpp/open3d/core/kernel/ArangeCUDA.cu
+++ b/cpp/open3d/core/kernel/ArangeCUDA.cu
@@ -24,21 +24,32 @@
 // IN THE SOFTWARE.
 // ----------------------------------------------------------------------------
 
-#pragma once
-
+#include "open3d/core/Dispatch.h"
 #include "open3d/core/Tensor.h"
+#include "open3d/core/kernel/Arange.h"
+#include "open3d/core/kernel/CUDALauncher.cuh"
 
 namespace open3d {
 namespace core {
 namespace kernel {
 
-Tensor NonZero(const Tensor& src);
-
-Tensor NonZeroCPU(const Tensor& src);
-
-#ifdef BUILD_CUDA_MODULE
-Tensor NonZeroCUDA(const Tensor& src);
-#endif
+void ArangeCUDA(const Tensor& start,
+                const Tensor& stop,
+                const Tensor& step,
+                Tensor& dst) {
+    Dtype dtype = start.GetDtype();
+    DISPATCH_DTYPE_TO_TEMPLATE(dtype, [&]() {
+        scalar_t sstart = start.Item<scalar_t>();
+        scalar_t sstep = step.Item<scalar_t>();
+        scalar_t* dst_ptr = static_cast<scalar_t*>(dst.GetDataPtr());
+        int64_t n = dst.GetLength();
+        CUDALauncher::LaunchGeneralKernel(n, [=] OPEN3D_HOST_DEVICE(
+                                                     int64_t workload_idx) {
+            dst_ptr[workload_idx] =
+                    sstart + static_cast<scalar_t>(sstep * workload_idx);
+        });
+    });
+}
 
 }  // namespace kernel
 }  // namespace core

--- a/cpp/open3d/core/kernel/GeneralEWCPU.cpp
+++ b/cpp/open3d/core/kernel/GeneralEWCPU.cpp
@@ -154,7 +154,7 @@ void GeneralEWCPU(const std::unordered_map<std::string, Tensor>& srcs,
             utility::LogError("[RayCasting] Unimplemented.");
             break;
         default:
-            break;
+            utility::LogError("Unimplemented.");
     }
 }
 

--- a/cpp/open3d/core/kernel/GeneralEWCUDA.cu
+++ b/cpp/open3d/core/kernel/GeneralEWCUDA.cu
@@ -150,7 +150,7 @@ void GeneralEWCUDA(const std::unordered_map<std::string, Tensor>& srcs,
             utility::LogError("[RayCasting] Unimplemented.");
             break;
         default:
-            break;
+            utility::LogError("Unimplemented.");
     }
 }
 

--- a/cpp/pybind/core/tensor.cpp
+++ b/cpp/pybind/core/tensor.cpp
@@ -280,6 +280,50 @@ void pybind_core_tensor(py::module& m) {
             "n"_a, "dtype"_a = py::none(), "device"_a = py::none());
     tensor.def_static("diag", &Tensor::Diag);
 
+    // Tensor creation from arange for int
+    tensor.def_static(
+            "arange",
+            [](int64_t stop, utility::optional<Device> device) {
+                return Tensor::Arange<int64_t>(
+                        0, stop, 1,
+                        device.has_value() ? device.value() : Device("CPU:0"));
+            },
+            "stop"_a, "device"_a = py::none());
+    tensor.def_static(
+            "arange",
+            [](utility::optional<int64_t> start, int64_t stop,
+               utility::optional<int64_t> step,
+               utility::optional<Device> device) {
+                return Tensor::Arange<int64_t>(
+                        start.has_value() ? start.value() : 0, stop,
+                        step.has_value() ? step.value() : 1,
+                        device.has_value() ? device.value() : Device("CPU:0"));
+            },
+            "start"_a = py::none(), "stop"_a, "step"_a = py::none(),
+            "device"_a = py::none());
+
+    // Tensor creation from arange for float
+    tensor.def_static(
+            "arange",
+            [](double stop, utility::optional<Device> device) {
+                return Tensor::Arange<double>(
+                        0.0, stop, 1.0,
+                        device.has_value() ? device.value() : Device("CPU:0"));
+            },
+            "stop"_a, "device"_a = py::none());
+    tensor.def_static(
+            "arange",
+            [](utility::optional<double> start, double stop,
+               utility::optional<double> step,
+               utility::optional<Device> device) {
+                return Tensor::Arange<double>(
+                        start.has_value() ? start.value() : 0.0, stop,
+                        step.has_value() ? step.value() : 1.0,
+                        device.has_value() ? device.value() : Device("CPU:0"));
+            },
+            "start"_a = py::none(), "stop"_a, "step"_a = py::none(),
+            "device"_a = py::none());
+
     // Tensor copy.
     tensor.def("shallow_copy_from", &Tensor::ShallowCopyFrom);
 

--- a/cpp/tests/core/Tensor.cpp
+++ b/cpp/tests/core/Tensor.cpp
@@ -210,6 +210,58 @@ TEST_P(TensorPermuteDevices, WithInitValueSizeMismatch) {
                  std::runtime_error);
 }
 
+TEST_P(TensorPermuteDevices, Arange) {
+    core::Device device = GetParam();
+
+    // Test float.
+    std::vector<float> valsf{0, 1, 2, 3, 4};
+    float startf = 0.0;
+    float stopf = 5.0;
+    float stepf = 1.0;
+    core::Tensor arangef =
+            core::Tensor::Arange<float>(startf, stopf, stepf, device);
+    EXPECT_EQ(arangef.ToFlatVector<float>(), valsf);
+
+    // Test float with non-one step.
+    valsf = {0.1, 2.1, 4.1};
+    startf = 0.1;
+    stopf = 6.0;
+    stepf = 2.0;
+    arangef = core::Tensor::Arange<float>(startf, stopf, stepf, device);
+    EXPECT_EQ(arangef.ToFlatVector<float>(), valsf);
+
+    // Test float with negative step.
+    valsf = {0, -2.0, -4.0};
+    startf = 0.0;
+    stopf = -4.1;
+    stepf = -2.0;
+    arangef = core::Tensor::Arange<float>(startf, stopf, stepf, device);
+    EXPECT_EQ(arangef.ToFlatVector<float>(), valsf);
+
+    // Test empty set -- empty Tensor.
+    startf = 0.0;
+    stopf = 2.0;
+    stepf = -2.0;
+    arangef = core::Tensor::Arange<float>(startf, stopf, stepf, device);
+    EXPECT_EQ(arangef.NumElements(), 0);
+
+    // Test zero step -- error.
+    startf = 0.0;
+    stopf = 2.0;
+    stepf = 0.0;
+    EXPECT_THROW(core::Tensor::Arange<float>(startf, stopf, stepf, device),
+                 std::runtime_error);
+
+    // Test int.
+    std::vector<int64_t> valsi{0, 1, 2, 3, 4};
+    int64_t starti = 0;
+    int64_t stopi = 5;
+    int64_t stepi = 1;
+    core::Tensor arangei =
+            core::Tensor::Arange<int64_t>(starti, stopi, stepi, device);
+    EXPECT_EQ(arangei.ToFlatVector<int64_t>(), valsi);
+}
+
 TEST_P(TensorPermuteDevices, Fill) {
     core::Device device = GetParam();
     core::Tensor t(std::vector<float>(2 * 3, 0), {2, 3}, core::Dtype::Float32,

--- a/python/conda_meta/meta.yaml
+++ b/python/conda_meta/meta.yaml
@@ -22,7 +22,6 @@ requirements:
         - notebook
         - numpy
         - addict # Open3D-ML deps starts here (https://github.com/intel-isl/Open3D-ML/blob/master/requirements.txt)
-        - matplotlib
         - pandas
         - plyfile
         - pyyaml

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,3 @@ ipywidgets
 widgetsnbextension
 notebook
 numpy
-matplotlib

--- a/python/test/core/test_core.py
+++ b/python/test/core/test_core.py
@@ -178,6 +178,30 @@ def test_tensor_constructor(device):
     np.testing.assert_equal(np_t, o3_t.cpu().numpy())
 
 
+@pytest.mark.parametrize("device", list_devices())
+def test_arange(device):
+    # Full parameters.
+    setups = [(0, 10, 1), (0, 10, 1), (0.0, 10.0, 2.0), (0.0, -10.0, -2.0)]
+    for start, stop, step in setups:
+        np_t = np.arange(start, stop, step)
+        o3_t = o3d.core.Tensor.arange(start, stop, step, device)
+        np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    # Only stop.
+    for stop in [1.0, 2.0, 3.0, 1, 2, 3]:
+        np_t = np.arange(stop)
+        o3_t = o3d.core.Tensor.arange(stop, device)
+        np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+    # Only start, stop (step = 1).
+    setups = [(0, 10), (0, 10), (0.0, 10.0), (0.0, -10.0)]
+    for start, stop in setups:
+        np_t = np.arange(start, stop)
+        # Not full parameter list, need to specify device by kw.
+        o3_t = o3d.core.Tensor.arange(start, stop, device=device)
+        np.testing.assert_equal(np_t, o3_t.cpu().numpy())
+
+
 def test_tensor_from_to_numpy():
     # a->b copy; b, c share memory
     a = np.ones((2, 2))

--- a/util/ci_utils.sh
+++ b/util/ci_utils.sh
@@ -44,7 +44,7 @@ YAPF_VER="0.30.0"
 SPHINX_VER=3.1.2
 SPHINX_RTD_VER=0.5.0
 NBSPHINX_VER=0.7.1
-PILLOW_VER=7.2.0
+MATPLOTLIB_VER=3.3.3
 
 OPEN3D_INSTALL_DIR=~/open3d_install
 OPEN3D_SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. >/dev/null 2>&1 && pwd)"
@@ -415,8 +415,13 @@ install_docs_dependencies() {
     echo Install Python dependencies for building docs
     which python
     python -V
-    python -m pip install -U -q "wheel==$WHEEL_VER" "pip==$PIP_VER" "Pillow==$PILLOW_VER" \
-        "sphinx==$SPHINX_VER" "sphinx-rtd-theme==$SPHINX_RTD_VER" "nbsphinx==$NBSPHINX_VER"
+    python -m pip install -U -q \
+        "wheel==$WHEEL_VER" \
+        "pip==$PIP_VER" \
+        "matplotlib==$MATPLOTLIB_VER" \
+        "sphinx==$SPHINX_VER" \
+        "sphinx-rtd-theme==$SPHINX_RTD_VER" \
+        "nbsphinx==$NBSPHINX_VER"
     # m2r needs a patch for sphinx 3
     # https://github.com/sphinx-doc/sphinx/issues/7420
     python -m pip install -U -q "git+https://github.com/intel-isl/m2r@dev#egg=m2r"


### PR DESCRIPTION
* add arange for cpp

* implement pybind (with default argument problem)

* override pybind for consistent arange interface

* minor formatting

* use AssertShape and AssertDevice

* move arange kernels to separate files

* remove matlotlib as dependency

Co-authored-by: Yixing Lao <yixing.lao@gmail.com>